### PR TITLE
Add Harbor Codex parity runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Harbor parity artifacts
+benchmark/harbor_parity/outputs/
+benchmark/harbor_parity/workspaces/
+benchmark/harbor_parity/logs/
+.env
+*.env
+__pycache__/
+*.py[cod]

--- a/benchmark/harbor_parity/Dockerfile.agent
+++ b/benchmark/harbor_parity/Dockerfile.agent
@@ -1,0 +1,55 @@
+FROM node:22-bookworm-slim
+
+ARG CODEX_VERSION=0.118.0
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        python3 \
+        python3-pip \
+        python3-venv \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Match the useful CanItEdit Python dependencies without installing heavyweight vLLM.
+# The single vLLM task is mocked by the benchmark tests; this stub only prevents
+# import-time failures if the agent runs solution.py while editing.
+RUN python3 -m pip install --break-system-packages --no-cache-dir \
+        pandas==2.0.2 \
+        torch==2.1.2 \
+        z3-solver==4.12.2.0 \
+        coverage==7.3.2 \
+        scikit-learn==1.2.2 \
+        numpy==1.23.5 \
+        flask==2.2.5 \
+        scipy==1.10.1 \
+        autograd==1.6.2 \
+    && python3 - <<'PY'
+from pathlib import Path
+import site
+pkg = Path(site.getsitepackages()[0]) / "vllm"
+pkg.mkdir(parents=True, exist_ok=True)
+(pkg / "__init__.py").write_text(
+    "class LLM:\n"
+    "    def __init__(self, *args, **kwargs):\n"
+    "        self.args = args\n"
+    "        self.kwargs = kwargs\n"
+    "    def generate(self, *args, **kwargs):\n"
+    "        return []\n\n"
+    "class SamplingParams:\n"
+    "    def __init__(self, *args, **kwargs):\n"
+    "        self.args = args\n"
+    "        self.kwargs = kwargs\n",
+    encoding="utf-8",
+)
+PY
+
+RUN npm install -g "@openai/codex@${CODEX_VERSION}" \
+    && codex --version
+
+WORKDIR /workspace

--- a/benchmark/harbor_parity/Dockerfile.agent
+++ b/benchmark/harbor_parity/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM python:3.10-slim
 
 ARG CODEX_VERSION=0.118.0
 ENV DEBIAN_FRONTEND=noninteractive
@@ -10,10 +10,9 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
-        python3 \
-        python3-pip \
-        python3-venv \
         ripgrep \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Match the useful CanItEdit Python dependencies without installing heavyweight vLLM.

--- a/benchmark/harbor_parity/Dockerfile.agent
+++ b/benchmark/harbor_parity/Dockerfile.agent
@@ -11,8 +11,6 @@ RUN apt-get update \
         curl \
         git \
         ripgrep \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Match the useful CanItEdit Python dependencies without installing heavyweight vLLM.
@@ -48,7 +46,14 @@ pkg.mkdir(parents=True, exist_ok=True)
 )
 PY
 
-RUN npm install -g "@openai/codex@${CODEX_VERSION}" \
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash \
+    && export NVM_DIR="$HOME/.nvm" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install 22 \
+    && nvm alias default 22 \
+    && npm install -g "@openai/codex@${CODEX_VERSION}" \
+    && ln -sf "$(which node)" /usr/local/bin/node \
+    && ln -sf "$(which codex)" /usr/local/bin/codex \
     && codex --version
 
 WORKDIR /workspace

--- a/benchmark/harbor_parity/Dockerfile.agent
+++ b/benchmark/harbor_parity/Dockerfile.agent
@@ -10,6 +10,8 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
+        nodejs \
+        npm \
         ripgrep \
     && rm -rf /var/lib/apt/lists/*
 

--- a/benchmark/harbor_parity/README.md
+++ b/benchmark/harbor_parity/README.md
@@ -32,14 +32,14 @@ codex exec \
   -- "$(cat /workspace/prompt.md)"
 ```
 
-The prompt text must match the Harbor adapter prompt.
+The inner CanItEdit prompt is the original direct-edit prompt from `benchmark/generate_completions.py` (`DirectEditModel.format_prompt`). The only Codex-specific addition is a writeback wrapper that tells the agent to put the edited code in `/workspace/solution.py` instead of returning it in chat. The complete Codex instruction must match the Harbor adapter instruction.
 
 ## Isolation model
 
 For each task, `run_codex_completions.py` creates a clean Docker workspace containing only:
 
 - `/workspace/solution.py` — initialized to the CanItEdit `before` code
-- `/workspace/prompt.md` — edit instruction plus the same before code
+- `/workspace/prompt.md` — the original CanItEdit direct-edit prompt plus the minimal Codex writeback wrapper
 
 The agent container does **not** receive:
 

--- a/benchmark/harbor_parity/README.md
+++ b/benchmark/harbor_parity/README.md
@@ -1,6 +1,6 @@
 # CanItEdit Harbor Parity Runner
 
-This directory adds an original-side Harbor parity runner for CanItEdit. It does **not** change the official CanItEdit dataset or evaluator. It only adds a Codex CLI execution path so the original benchmark can be compared fairly with the Harbor adapter.
+This directory adds an original-side Harbor parity runner for CanItEdit. It does **not** change the official CanItEdit dataset or evaluator. It only adds a Codex CLI execution path so CanItEdit can be compared fairly with the Harbor adapter.
 
 ## Parity setting
 
@@ -29,10 +29,10 @@ codex exec \
   --enable unified_exec \
   -c model_reasoning_effort=low \
   -c model_reasoning_summary=none \
-  -- "<official-direct-prompt-plus-writeback-wrapper>"
+  -- "<direct-edit-prompt-plus-writeback-instruction>"
 ```
 
-The inner CanItEdit prompt is the original direct-edit prompt from `benchmark/generate_completions.py` (`DirectEditModel.format_prompt`). The only Codex-specific addition is a writeback wrapper that tells the agent to put the edited code in `/workspace/solution.py` instead of returning it in chat. The complete Codex instruction must match the Harbor adapter instruction.
+The task content is the direct-edit prompt from `benchmark/generate_completions.py` (`DirectEditModel.format_prompt`). The only Codex-specific addition is a neutral writeback instruction that tells the agent to put the edited code in `/workspace/solution.py` instead of returning it in chat. The complete Codex instruction must match the Harbor adapter instruction.
 
 ## Isolation model
 

--- a/benchmark/harbor_parity/README.md
+++ b/benchmark/harbor_parity/README.md
@@ -29,7 +29,7 @@ codex exec \
   --enable unified_exec \
   -c model_reasoning_effort=low \
   -c model_reasoning_summary=none \
-  -- "$(cat /workspace/prompt.md)"
+  -- "<official-direct-prompt-plus-writeback-wrapper>"
 ```
 
 The inner CanItEdit prompt is the original direct-edit prompt from `benchmark/generate_completions.py` (`DirectEditModel.format_prompt`). The only Codex-specific addition is a writeback wrapper that tells the agent to put the edited code in `/workspace/solution.py` instead of returning it in chat. The complete Codex instruction must match the Harbor adapter instruction.
@@ -39,7 +39,8 @@ The inner CanItEdit prompt is the original direct-edit prompt from `benchmark/ge
 For each task, `run_codex_completions.py` creates a clean Docker workspace containing only:
 
 - `/workspace/solution.py` — initialized to the CanItEdit `before` code
-- `/workspace/prompt.md` — the original CanItEdit direct-edit prompt plus the minimal Codex writeback wrapper
+
+The Codex instruction is passed as the `codex exec -- <instruction>` argument, matching Harbor's Codex invocation. No prompt file is placed in `/workspace`.
 
 The agent container does **not** receive:
 

--- a/benchmark/harbor_parity/README.md
+++ b/benchmark/harbor_parity/README.md
@@ -1,0 +1,123 @@
+# CanItEdit Harbor Parity Runner
+
+This directory adds an original-side Harbor parity runner for CanItEdit. It does **not** change the official CanItEdit dataset or evaluator. It only adds a Codex CLI execution path so the original benchmark can be compared fairly with the Harbor adapter.
+
+## Parity setting
+
+Use the same setting on both the original CanItEdit side and the Harbor side:
+
+- Dataset: `nuprl/CanItEdit`
+- Split: `test`
+- Dataset revision: `3c07f38b1f9385f3214fcea94d4664c79df0d36a`
+- Tasks: 210 total = 105 examples × `instruction_descriptive` and `instruction_lazy`
+- Agent: `codex@0.118.0`
+- Model: `gpt-5-mini`
+- Reasoning effort: `low`
+- Reasoning summary: `none`
+- Completion count: 1
+- Metric: pass@1 / resolved rate / accuracy
+- Agent timeout: 600 seconds per task
+
+Codex is run with:
+
+```bash
+codex exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  --skip-git-repo-check \
+  --model gpt-5-mini \
+  --json \
+  --enable unified_exec \
+  -c model_reasoning_effort=low \
+  -c model_reasoning_summary=none \
+  - < /workspace/prompt.md
+```
+
+The prompt text must match the Harbor adapter prompt.
+
+## Isolation model
+
+For each task, `run_codex_completions.py` creates a clean Docker workspace containing only:
+
+- `/workspace/solution.py` — initialized to the CanItEdit `before` code
+- `/workspace/prompt.md` — edit instruction plus the same before code
+
+The agent container does **not** receive:
+
+- official tests
+- `after` reference code
+- CanItEdit repository files
+- benchmark outputs from other tasks
+
+The script reads the final `/workspace/solution.py` and writes it as one official CanItEdit completion. Official tests and `after` code are present only in the generated completion JSON used by the official evaluator.
+
+## Build the agent image
+
+```bash
+docker build \
+  -f benchmark/harbor_parity/Dockerfile.agent \
+  --build-arg CODEX_VERSION=0.118.0 \
+  -t canitedit-codex-agent:0.118.0 \
+  .
+```
+
+## Run original-side completions
+
+Set parity API environment variables first. Do not commit them.
+
+```bash
+export OPENAI_API_KEY="..."
+export OPENAI_BASE_URL="..."  # only if using a non-default OpenAI-compatible endpoint
+```
+
+Run one full parity round:
+
+```bash
+uv run --script benchmark/harbor_parity/run_codex_completions.py \
+  --output-dir benchmark/harbor_parity/outputs/original_run1 \
+  --agent-image canitedit-codex-agent:0.118.0 \
+  --model gpt-5-mini \
+  --codex-version 0.118.0 \
+  --reasoning-effort low \
+  --reasoning-summary none \
+  --dataset-revision 3c07f38b1f9385f3214fcea94d4664c79df0d36a \
+  --instruction-kinds both \
+  --timeout-sec 600
+```
+
+Repeat with `original_run2` and `original_run3`.
+
+For a no-API selection check:
+
+```bash
+uv run --script benchmark/harbor_parity/run_codex_completions.py \
+  --output-dir /tmp/canitedit-dry-run \
+  --limit 2 \
+  --dry-run
+```
+
+## Evaluate with the official CanItEdit evaluator
+
+The official evaluator remains unchanged:
+
+```bash
+podman run --rm --network none \
+  --volume benchmark/harbor_parity/outputs/original_run1:/data:rw \
+  ghcr.io/nuprl/canitedit \
+  --dir /data --output-dir /data
+```
+
+`docker run` can be used instead of `podman run` if Docker is the available runtime.
+
+## Collect scores
+
+```bash
+python benchmark/harbor_parity/collect_scores.py \
+  --results-dir benchmark/harbor_parity/outputs/original_run1 \
+  --output benchmark/harbor_parity/outputs/original_run1_summary.json
+```
+
+The summary reports `accuracy_percent = resolved / total * 100`. Use the three original-side run scores and the three Harbor-side run scores to report mean ± sample SEM and check run-range overlap.
+
+## Artifact policy
+
+Do not commit generated outputs, logs, traces, workspaces, or API keys. Keep run artifacts locally and upload them separately to the Harbor parity experiments dataset when the Harbor adapter PR is ready.

--- a/benchmark/harbor_parity/README.md
+++ b/benchmark/harbor_parity/README.md
@@ -119,6 +119,3 @@ python benchmark/harbor_parity/collect_scores.py \
 
 The summary reports `accuracy_percent = resolved / total * 100`. Use the three original-side run scores and the three Harbor-side run scores to report mean ± sample SEM and check run-range overlap.
 
-## Artifact policy
-
-Do not commit generated outputs, logs, traces, workspaces, or API keys. Keep run artifacts locally and upload them separately to the Harbor parity experiments dataset when the Harbor adapter PR is ready.

--- a/benchmark/harbor_parity/README.md
+++ b/benchmark/harbor_parity/README.md
@@ -29,7 +29,7 @@ codex exec \
   --enable unified_exec \
   -c model_reasoning_effort=low \
   -c model_reasoning_summary=none \
-  - < /workspace/prompt.md
+  -- "$(cat /workspace/prompt.md)"
 ```
 
 The prompt text must match the Harbor adapter prompt.

--- a/benchmark/harbor_parity/collect_scores.py
+++ b/benchmark/harbor_parity/collect_scores.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Collect CanItEdit official evaluator results for Harbor parity runs."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+from pathlib import Path
+from typing import Any
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            return json.load(f)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def is_success(result: dict[str, Any]) -> bool:
+    return result.get("status") == "OK" and result.get("exit_code") == 0
+
+
+def collect(results_dir: Path) -> dict[str, Any]:
+    paths = sorted(results_dir.glob("*.results.json")) + sorted(
+        results_dir.glob("*.results.json.gz")
+    )
+    if not paths:
+        raise FileNotFoundError(
+            f"No official evaluator result files found in {results_dir}. "
+            "Run ghcr.io/nuprl/canitedit first."
+        )
+
+    tasks: list[dict[str, Any]] = []
+    for path in paths:
+        payload = read_json(path)
+        completions = payload.get("results") or []
+        passed = any(is_success(result) for result in completions if isinstance(result, dict))
+        first = completions[0] if completions and isinstance(completions[0], dict) else {}
+        tasks.append(
+            {
+                "file": path.name,
+                "id": payload.get("id"),
+                "full_name": payload.get("full_name"),
+                "instr_kind": payload.get("instr_kind"),
+                "passed": passed,
+                "num_completions": len(completions),
+                "status": first.get("status"),
+                "exit_code": first.get("exit_code"),
+                "stderr": first.get("stderr"),
+            }
+        )
+
+    num_tasks = len(tasks)
+    num_resolved = sum(1 for task in tasks if task["passed"])
+    accuracy = num_resolved / num_tasks if num_tasks else 0.0
+    return {
+        "results_dir": str(results_dir),
+        "num_tasks": num_tasks,
+        "num_resolved": num_resolved,
+        "accuracy": accuracy,
+        "accuracy_percent": accuracy * 100,
+        "tasks": tasks,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results-dir", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    summary = collect(args.results_dir)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(
+        f"accuracy={summary['accuracy_percent']:.2f}% "
+        f"({summary['num_resolved']}/{summary['num_tasks']})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -53,7 +53,7 @@ DEFAULT_MAX_TOKENS = 3072
 InstructionKind = Literal["instruction_descriptive", "instruction_lazy"]
 
 
-CODEX_WRITEBACK_TEMPLATE = """The following is the original CanItEdit direct-edit prompt. In the original benchmark, the model returns the edited code after `## Code After:`.
+CODEX_WRITEBACK_TEMPLATE = """The following is the original direct-edit prompt. In the original benchmark, the model returns the edited code after `## Code After:`.
 
 For this Codex parity run, apply the same edit by writing the final edited Python code to `/workspace/solution.py` instead of returning it in chat. Do not create a different answer file.
 

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -50,9 +50,8 @@ DEFAULT_TIMEOUT_SEC = 600
 InstructionKind = Literal["instruction_descriptive", "instruction_lazy"]
 
 
-CODEX_WRITEBACK_TEMPLATE = """The following is the original direct-edit prompt. In the original benchmark, the model returns the edited code after `## Code After:`.
-
-For this Codex parity run, apply the same edit by writing the final edited Python code to `/workspace/solution.py` instead of returning it in chat. Do not create a different answer file.
+CODEX_WRITEBACK_TEMPLATE = """Apply the requested edit by writing the complete final edited Python code to `/workspace/solution.py`.
+Do not return the edited code in chat. Do not create any other answer file.
 
 {official_prompt}"""
 
@@ -233,7 +232,7 @@ def codex_shell_script(args: argparse.Namespace) -> str:
     return f"""
 set -euo pipefail
 if [ -z "${{OPENAI_API_KEY:-}}" ]; then
-  echo "OPENAI_API_KEY is required for Codex parity runs" >&2
+  echo "OPENAI_API_KEY is required for Codex runs" >&2
   exit 2
 fi
 export CODEX_HOME=/tmp/codex-home

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -239,7 +239,7 @@ home.mkdir(parents=True, exist_ok=True)
 (home / "auth.json").write_text(json.dumps({{"OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", "")}}), encoding="utf-8")
 base_url = os.environ.get("OPENAI_BASE_URL")
 if base_url:
-    (home / "config.toml").write_text(f"openai_base_url = {{json.dumps(base_url)}}\n", encoding="utf-8")
+    (home / "config.toml").write_text(f"openai_base_url = {{json.dumps(base_url)}}\\n", encoding="utf-8")
 PY_SETUP
 prompt="$1"
 set +e
@@ -315,7 +315,7 @@ def run_codex_for_item(
     started = time.time()
     timed_out = False
     try:
-        result = run_command(command, timeout=args.timeout_sec + 90)
+        result = run_command(command, timeout=args.timeout_sec)
     except subprocess.TimeoutExpired:
         timed_out = True
         subprocess.run(
@@ -332,6 +332,12 @@ def run_codex_for_item(
 
     (task_logs_dir / "docker_stdout.txt").write_text(result.stdout or "", encoding="utf-8")
     (task_logs_dir / "docker_stderr.txt").write_text(result.stderr or "", encoding="utf-8")
+
+    if result.returncode != 0 and not args.allow_agent_failures:
+        raise RuntimeError(
+            f"Codex exited with code {result.returncode} for {item.safe_name}. "
+            f"Logs are in {task_logs_dir}. Pass --allow-agent-failures only for debugging."
+        )
 
     payload = dict(item.example)
     payload.update(
@@ -423,6 +429,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--keep-workspaces", action="store_true")
+    parser.add_argument(
+        "--allow-agent-failures",
+        action="store_true",
+        help="Write completion files even when Codex exits non-zero; use only for debugging.",
+    )
     parser.add_argument("--allow-version-mismatch", action="store_true")
     parser.add_argument("--dry-run", action="store_true", help="List selected tasks without running Codex")
     args = parser.parse_args(argv)

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -161,8 +161,19 @@ def build_official_prompt(item: TaskItem) -> str:
     )
 
 
+def render_writeback_template(template: str, replacements: dict[str, str]) -> str:
+    def replace_match(match: re.Match[str]) -> str:
+        key = match.group(1)
+        return replacements.get(key, match.group(0))
+
+    return re.sub(r"\{([A-Za-z_][A-Za-z0-9_]*)\}", replace_match, template)
+
+
 def build_codex_instruction(item: TaskItem) -> str:
-    return CODEX_WRITEBACK_TEMPLATE.format(official_prompt=build_official_prompt(item))
+    return render_writeback_template(
+        CODEX_WRITEBACK_TEMPLATE,
+        {"official_prompt": build_official_prompt(item)},
+    )
 
 
 def run_command(

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -3,6 +3,8 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "datasets==4.0.*",
+#     "litellm",
+#     "tqdm",
 # ]
 # ///
 """Run Harbor-style Codex parity completions for CanItEdit.
@@ -17,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import importlib.util
 import json
 import os
 import re
@@ -49,20 +52,11 @@ DEFAULT_MAX_TOKENS = 3072
 InstructionKind = Literal["instruction_descriptive", "instruction_lazy"]
 
 
-PROMPT_TEMPLATE = """You need to edit a Python file.
+CODEX_WRITEBACK_TEMPLATE = """The following is the original CanItEdit direct-edit prompt. In the original benchmark, the model returns the edited code after `## Code After:`.
 
-The file /workspace/solution.py contains the current code. Modify that file so it satisfies the edit request below.
+For this Codex parity run, apply the same edit by writing the final edited Python code to `/workspace/solution.py` instead of returning it in chat. Do not create a different answer file.
 
-Do not create a different final answer file. Do not modify or look up benchmark tests, reference solutions, or external benchmark data. When you are done, the complete edited Python program must be in /workspace/solution.py.
-
-## Code Before
-```python
-{before}
-```
-
-## Edit Instruction
-{instruction}
-"""
+{official_prompt}"""
 
 
 @dataclass(frozen=True)
@@ -144,8 +138,29 @@ def load_task_items(args: argparse.Namespace) -> list[TaskItem]:
     return items
 
 
-def build_prompt(item: TaskItem) -> str:
-    return PROMPT_TEMPLATE.format(before=item.before.rstrip(), instruction=item.instruction.strip())
+def load_official_direct_model_class() -> type:
+    official_path = Path(__file__).resolve().parents[1] / "generate_completions.py"
+    spec = importlib.util.spec_from_file_location("canitedit_generate_completions", official_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load official CanItEdit generator from {official_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.DirectEditModel
+
+
+def build_official_prompt(item: TaskItem) -> str:
+    # Intentionally delegates to the official CanItEdit prompt builder instead of
+    # reimplementing its template. This preserves upstream prompt/config semantics.
+    direct_model_cls = load_official_direct_model_class()
+    return direct_model_cls(model_name="codex-parity-placeholder", one_shot=False).format_prompt(
+        item.before,
+        item.instruction,
+    )
+
+
+def build_codex_instruction(item: TaskItem) -> str:
+    return CODEX_WRITEBACK_TEMPLATE.format(official_prompt=build_official_prompt(item))
 
 
 def run_command(
@@ -272,7 +287,7 @@ def run_codex_for_item(
     task_logs_dir.mkdir(parents=True, exist_ok=True)
 
     (task_work_dir / "solution.py").write_text(item.before, encoding="utf-8")
-    (task_work_dir / "prompt.md").write_text(build_prompt(item), encoding="utf-8")
+    (task_work_dir / "prompt.md").write_text(build_codex_instruction(item), encoding="utf-8")
 
     container_name = f"canitedit-parity-{item.safe_name[:48]}-{uuid.uuid4().hex[:8]}"
     command = [

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -46,9 +46,6 @@ DEFAULT_REASONING_EFFORT = "low"
 DEFAULT_REASONING_SUMMARY = "none"
 DEFAULT_AGENT_IMAGE = f"canitedit-codex-agent:{DEFAULT_CODEX_VERSION}"
 DEFAULT_TIMEOUT_SEC = 600
-DEFAULT_TEMPERATURE = 0.2
-DEFAULT_TOP_P = 0.95
-DEFAULT_MAX_TOKENS = 3072
 
 InstructionKind = Literal["instruction_descriptive", "instruction_lazy"]
 
@@ -357,10 +354,6 @@ def run_codex_for_item(
             "prompt": "",
             "completions": [completion],
             "language": "py",
-            "temperature": args.temperature,
-            "top_p": args.top_p,
-            "max_tokens": args.max_tokens,
-            "stop_tokens": [],
             "script_args": sanitized_script_args(args),
             "harbor_parity_metadata": {
                 "agent": DEFAULT_AGENT,
@@ -435,9 +428,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--task-ids", default=None, help="Comma-separated id/name/full_name filter")
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--timeout-sec", type=int, default=DEFAULT_TIMEOUT_SEC)
-    parser.add_argument("--temperature", type=float, default=DEFAULT_TEMPERATURE)
-    parser.add_argument("--top-p", type=float, default=DEFAULT_TOP_P)
-    parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--keep-workspaces", action="store_true")
     parser.add_argument(

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "datasets==4.0.*",
+# ]
+# ///
+"""Run Harbor-style Codex parity completions for CanItEdit.
+
+This script is intentionally limited to the original-side parity use case:
+it runs Codex in a clean Docker workspace where only the before-code and edit
+instruction are visible, then writes CanItEdit official-evaluator-compatible
+completion JSON files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+from datasets import load_dataset
+
+DEFAULT_DATASET = "nuprl/CanItEdit"
+DEFAULT_DATASET_REVISION = "3c07f38b1f9385f3214fcea94d4664c79df0d36a"
+DEFAULT_SPLIT = "test"
+DEFAULT_AGENT = "codex"
+DEFAULT_CODEX_VERSION = "0.118.0"
+DEFAULT_MODEL = "gpt-5-mini"
+DEFAULT_REASONING_EFFORT = "low"
+DEFAULT_REASONING_SUMMARY = "none"
+DEFAULT_AGENT_IMAGE = f"canitedit-codex-agent:{DEFAULT_CODEX_VERSION}"
+DEFAULT_TIMEOUT_SEC = 600
+DEFAULT_TEMPERATURE = 0.2
+DEFAULT_TOP_P = 0.95
+DEFAULT_MAX_TOKENS = 3072
+
+InstructionKind = Literal["instruction_descriptive", "instruction_lazy"]
+
+
+PROMPT_TEMPLATE = """You need to edit a Python file.
+
+The file /workspace/solution.py contains the current code. Modify that file so it satisfies the edit request below.
+
+Do not create a different final answer file. Do not modify or look up benchmark tests, reference solutions, or external benchmark data. When you are done, the complete edited Python program must be in /workspace/solution.py.
+
+## Code Before
+```python
+{before}
+```
+
+## Edit Instruction
+{instruction}
+"""
+
+
+@dataclass(frozen=True)
+class TaskItem:
+    example: dict[str, Any]
+    instr_kind: InstructionKind
+
+    @property
+    def output_name(self) -> str:
+        return f"{self.example['full_name']}_{self.instr_kind}.json.gz"
+
+    @property
+    def safe_name(self) -> str:
+        raw = f"{self.example['full_name']}_{self.instr_kind}"
+        return re.sub(r"[^A-Za-z0-9_.-]+", "_", raw)
+
+    @property
+    def instruction(self) -> str:
+        value = self.example.get(self.instr_kind)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(
+                f"Missing instruction text for {self.example.get('full_name')} {self.instr_kind}"
+            )
+        return value
+
+    @property
+    def before(self) -> str:
+        value = self.example.get("before")
+        if not isinstance(value, str):
+            raise ValueError(f"Missing before code for {self.example.get('full_name')}")
+        return value
+
+
+def write_json_gz(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False)
+
+
+def parse_instruction_kinds(value: str) -> list[InstructionKind]:
+    normalized = value.strip().lower()
+    if normalized == "both":
+        return ["instruction_descriptive", "instruction_lazy"]
+    if normalized in {"descriptive", "instruction_descriptive"}:
+        return ["instruction_descriptive"]
+    if normalized in {"lazy", "instruction_lazy"}:
+        return ["instruction_lazy"]
+    raise ValueError(
+        "--instruction-kinds must be one of: both, descriptive, lazy, "
+        "instruction_descriptive, instruction_lazy"
+    )
+
+
+def load_task_items(args: argparse.Namespace) -> list[TaskItem]:
+    dataset = load_dataset(
+        args.dataset,
+        args.subset,
+        split=args.split,
+        revision=args.dataset_revision,
+    )
+    instruction_kinds = parse_instruction_kinds(args.instruction_kinds)
+
+    allow_ids: set[str] | None = None
+    if args.task_ids:
+        allow_ids = {part.strip() for part in args.task_ids.split(",") if part.strip()}
+
+    items: list[TaskItem] = []
+    for row in dataset:
+        ex = dict(row)
+        if allow_ids is not None:
+            identifiers = {str(ex.get("id")), str(ex.get("name")), str(ex.get("full_name"))}
+            if identifiers.isdisjoint(allow_ids):
+                continue
+        for instr_kind in instruction_kinds:
+            items.append(TaskItem(example=ex, instr_kind=instr_kind))
+
+    if args.limit is not None:
+        items = items[: args.limit]
+    return items
+
+
+def build_prompt(item: TaskItem) -> str:
+    return PROMPT_TEMPLATE.format(before=item.before.rstrip(), instruction=item.instruction.strip())
+
+
+def run_command(
+    command: list[str], *, timeout: int | None = None, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def get_image_codex_version(args: argparse.Namespace) -> str:
+    command = [
+        args.docker_binary,
+        "run",
+        "--rm",
+        args.agent_image,
+        "bash",
+        "-lc",
+        "codex --version",
+    ]
+    result = run_command(command, timeout=60)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Unable to inspect Codex version in agent image. "
+            f"Command stderr:\n{result.stderr.strip()}"
+        )
+    output = result.stdout.strip().splitlines()
+    if not output:
+        raise RuntimeError("codex --version returned no output in agent image")
+    version_line = output[-1].strip()
+    return version_line.removeprefix("codex-cli").strip()
+
+
+def ensure_codex_version(args: argparse.Namespace) -> str:
+    observed = get_image_codex_version(args)
+    if observed != args.codex_version and not args.allow_version_mismatch:
+        raise RuntimeError(
+            f"Agent image has codex version {observed!r}; expected {args.codex_version!r}. "
+            "Rebuild Dockerfile.agent or pass --allow-version-mismatch only for debugging."
+        )
+    return observed
+
+
+def docker_env_flags() -> list[str]:
+    flags = ["-e", "OPENAI_API_KEY"]
+    if os.environ.get("OPENAI_BASE_URL"):
+        flags.extend(["-e", "OPENAI_BASE_URL"])
+    return flags
+
+
+def codex_shell_script(args: argparse.Namespace) -> str:
+    # Keep secrets out of docker command arguments. The key is copied from the
+    # container environment into an ephemeral CODEX_HOME auth.json, then removed.
+    return f"""
+set -euo pipefail
+if [ -z "${{OPENAI_API_KEY:-}}" ]; then
+  echo "OPENAI_API_KEY is required for Codex parity runs" >&2
+  exit 2
+fi
+export CODEX_HOME=/tmp/codex-home
+mkdir -p "$CODEX_HOME" /logs
+python3 - <<'PY_SETUP'
+import json
+import os
+from pathlib import Path
+home = Path(os.environ["CODEX_HOME"])
+home.mkdir(parents=True, exist_ok=True)
+(home / "auth.json").write_text(json.dumps({{"OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", "")}}), encoding="utf-8")
+base_url = os.environ.get("OPENAI_BASE_URL")
+if base_url:
+    (home / "config.toml").write_text(f"openai_base_url = {{json.dumps(base_url)}}\n", encoding="utf-8")
+PY_SETUP
+set +e
+codex exec \
+  --dangerously-bypass-approvals-and-sandbox \
+  --skip-git-repo-check \
+  --model {args.model} \
+  --json \
+  --enable unified_exec \
+  -c model_reasoning_effort={args.reasoning_effort} \
+  -c model_reasoning_summary={args.reasoning_summary} \
+  - < /workspace/prompt.md 2>&1 | tee /logs/codex.jsonl
+status=${{PIPESTATUS[0]}}
+set -e
+rm -f "$CODEX_HOME/auth.json" "$CODEX_HOME/config.toml"
+if [ -d "$CODEX_HOME/sessions" ]; then
+  rm -rf /logs/sessions
+  cp -R "$CODEX_HOME/sessions" /logs/sessions
+fi
+rm -rf "$CODEX_HOME"
+exit "$status"
+""".strip()
+
+
+def run_codex_for_item(
+    item: TaskItem,
+    args: argparse.Namespace,
+    output_dir: Path,
+    work_root: Path,
+    codex_version_observed: str,
+) -> dict[str, Any]:
+    completion_path = output_dir / item.output_name
+    if completion_path.exists() and not args.overwrite:
+        return {"skipped": True, "path": str(completion_path)}
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError("OPENAI_API_KEY is required unless --dry-run is used")
+
+    task_work_dir = work_root / item.safe_name
+    task_logs_dir = output_dir / "logs" / item.safe_name
+    if task_work_dir.exists():
+        shutil.rmtree(task_work_dir)
+    if task_logs_dir.exists() and args.overwrite:
+        shutil.rmtree(task_logs_dir)
+    task_work_dir.mkdir(parents=True, exist_ok=True)
+    task_logs_dir.mkdir(parents=True, exist_ok=True)
+
+    (task_work_dir / "solution.py").write_text(item.before, encoding="utf-8")
+    (task_work_dir / "prompt.md").write_text(build_prompt(item), encoding="utf-8")
+
+    container_name = f"canitedit-parity-{item.safe_name[:48]}-{uuid.uuid4().hex[:8]}"
+    command = [
+        args.docker_binary,
+        "run",
+        "--rm",
+        "--name",
+        container_name,
+        *docker_env_flags(),
+        "-v",
+        f"{task_work_dir.resolve()}:/workspace:rw",
+        "-v",
+        f"{task_logs_dir.resolve()}:/logs:rw",
+        "-w",
+        "/workspace",
+        args.agent_image,
+        "bash",
+        "-lc",
+        codex_shell_script(args),
+    ]
+
+    started = time.time()
+    timed_out = False
+    try:
+        result = run_command(command, timeout=args.timeout_sec + 90)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        subprocess.run(
+            [args.docker_binary, "rm", "-f", container_name],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        result = subprocess.CompletedProcess(command, returncode=124, stdout="", stderr="timeout")
+    duration_sec = time.time() - started
+
+    solution_path = task_work_dir / "solution.py"
+    completion = solution_path.read_text(encoding="utf-8") if solution_path.exists() else ""
+
+    (task_logs_dir / "docker_stdout.txt").write_text(result.stdout or "", encoding="utf-8")
+    (task_logs_dir / "docker_stderr.txt").write_text(result.stderr or "", encoding="utf-8")
+
+    payload = dict(item.example)
+    payload.update(
+        {
+            "instr_kind": item.instr_kind,
+            "prompt": "",
+            "completions": [completion],
+            "language": "py",
+            "temperature": args.temperature,
+            "top_p": args.top_p,
+            "max_tokens": args.max_tokens,
+            "stop_tokens": [],
+            "script_args": sanitized_script_args(args),
+            "harbor_parity_metadata": {
+                "agent": DEFAULT_AGENT,
+                "agent_image": args.agent_image,
+                "codex_version_expected": args.codex_version,
+                "codex_version_observed": codex_version_observed,
+                "model": args.model,
+                "reasoning_effort": args.reasoning_effort,
+                "reasoning_summary": args.reasoning_summary,
+                "timeout_sec": args.timeout_sec,
+                "duration_sec": round(duration_sec, 3),
+                "exit_code": result.returncode,
+                "timed_out": timed_out,
+                "trace_path": str((Path("logs") / item.safe_name).as_posix()),
+                "openai_base_url_configured": bool(os.environ.get("OPENAI_BASE_URL")),
+            },
+        }
+    )
+    write_json_gz(completion_path, payload)
+
+    if not args.keep_workspaces:
+        shutil.rmtree(task_work_dir, ignore_errors=True)
+
+    return {
+        "skipped": False,
+        "path": str(completion_path),
+        "exit_code": result.returncode,
+        "duration_sec": duration_sec,
+    }
+
+
+def sanitized_script_args(args: argparse.Namespace) -> dict[str, Any]:
+    hidden = {"dry_run"}
+    result: dict[str, Any] = {}
+    for key, value in vars(args).items():
+        if key in hidden:
+            continue
+        if isinstance(value, Path):
+            result[key] = str(value)
+        else:
+            result[key] = value
+    return result
+
+
+def summarize_selection(items: Iterable[TaskItem]) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": item.example.get("id"),
+            "full_name": item.example.get("full_name"),
+            "instr_kind": item.instr_kind,
+            "output_name": item.output_name,
+        }
+        for item in items
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    parser.add_argument("--dataset-revision", default=DEFAULT_DATASET_REVISION)
+    parser.add_argument("--split", default=DEFAULT_SPLIT)
+    parser.add_argument("--subset", default=None)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--work-dir", type=Path, default=None)
+    parser.add_argument("--agent-image", default=DEFAULT_AGENT_IMAGE)
+    parser.add_argument("--docker-binary", default="docker")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--codex-version", default=DEFAULT_CODEX_VERSION)
+    parser.add_argument("--reasoning-effort", default=DEFAULT_REASONING_EFFORT)
+    parser.add_argument("--reasoning-summary", default=DEFAULT_REASONING_SUMMARY)
+    parser.add_argument("--instruction-kinds", default="both")
+    parser.add_argument("--task-ids", default=None, help="Comma-separated id/name/full_name filter")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--timeout-sec", type=int, default=DEFAULT_TIMEOUT_SEC)
+    parser.add_argument("--temperature", type=float, default=DEFAULT_TEMPERATURE)
+    parser.add_argument("--top-p", type=float, default=DEFAULT_TOP_P)
+    parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--keep-workspaces", action="store_true")
+    parser.add_argument("--allow-version-mismatch", action="store_true")
+    parser.add_argument("--dry-run", action="store_true", help="List selected tasks without running Codex")
+    args = parser.parse_args(argv)
+
+    if args.limit is not None and args.limit < 1:
+        parser.error("--limit must be >= 1")
+
+    items = load_task_items(args)
+    if not items:
+        raise RuntimeError("No CanItEdit tasks selected")
+
+    if args.dry_run:
+        print(json.dumps({"num_items": len(items), "items": summarize_selection(items)}, indent=2))
+        return 0
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    work_root = args.work_dir or Path(tempfile.mkdtemp(prefix="canitedit-parity-work-"))
+    work_root.mkdir(parents=True, exist_ok=True)
+
+    codex_version_observed = ensure_codex_version(args)
+    print(
+        f"Running {len(items)} CanItEdit parity items with codex@{codex_version_observed} + {args.model}",
+        flush=True,
+    )
+
+    summary: list[dict[str, Any]] = []
+    try:
+        for index, item in enumerate(items, start=1):
+            print(f"[{index}/{len(items)}] {item.example['full_name']} {item.instr_kind}", flush=True)
+            result = run_codex_for_item(item, args, args.output_dir, work_root, codex_version_observed)
+            summary.append(
+                {
+                    "id": item.example.get("id"),
+                    "full_name": item.example.get("full_name"),
+                    "instr_kind": item.instr_kind,
+                    **result,
+                }
+            )
+    finally:
+        if args.work_dir is None and not args.keep_workspaces:
+            shutil.rmtree(work_root, ignore_errors=True)
+
+    (args.output_dir / "run_codex_completions_summary.json").write_text(
+        json.dumps(
+            {
+                "dataset": args.dataset,
+                "dataset_revision": args.dataset_revision,
+                "split": args.split,
+                "num_items": len(items),
+                "agent": DEFAULT_AGENT,
+                "codex_version": codex_version_observed,
+                "model": args.model,
+                "reasoning_effort": args.reasoning_effort,
+                "reasoning_summary": args.reasoning_summary,
+                "items": summary,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -224,6 +224,8 @@ base_url = os.environ.get("OPENAI_BASE_URL")
 if base_url:
     (home / "config.toml").write_text(f"openai_base_url = {{json.dumps(base_url)}}\n", encoding="utf-8")
 PY_SETUP
+prompt="$(cat /workspace/prompt.md; printf __CANITEDIT_PROMPT_END__)"
+prompt="${prompt%__CANITEDIT_PROMPT_END__}"
 set +e
 codex exec \
   --dangerously-bypass-approvals-and-sandbox \
@@ -233,7 +235,7 @@ codex exec \
   --enable unified_exec \
   -c model_reasoning_effort={args.reasoning_effort} \
   -c model_reasoning_summary={args.reasoning_summary} \
-  - < /workspace/prompt.md 2>&1 | tee /logs/codex.jsonl
+  -- "$prompt" 2>&1 </dev/null | tee /logs/codex.jsonl
 status=${{PIPESTATUS[0]}}
 set -e
 rm -f "$CODEX_HOME/auth.json" "$CODEX_HOME/config.toml"

--- a/benchmark/harbor_parity/run_codex_completions.py
+++ b/benchmark/harbor_parity/run_codex_completions.py
@@ -30,6 +30,7 @@ import tempfile
 import time
 import uuid
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import Any, Iterable, Literal
 
@@ -138,6 +139,7 @@ def load_task_items(args: argparse.Namespace) -> list[TaskItem]:
     return items
 
 
+@cache
 def load_official_direct_model_class() -> type:
     official_path = Path(__file__).resolve().parents[1] / "generate_completions.py"
     spec = importlib.util.spec_from_file_location("canitedit_generate_completions", official_path)
@@ -239,8 +241,7 @@ base_url = os.environ.get("OPENAI_BASE_URL")
 if base_url:
     (home / "config.toml").write_text(f"openai_base_url = {{json.dumps(base_url)}}\n", encoding="utf-8")
 PY_SETUP
-prompt="$(cat /workspace/prompt.md; printf __CANITEDIT_PROMPT_END__)"
-prompt="${prompt%__CANITEDIT_PROMPT_END__}"
+prompt="$1"
 set +e
 codex exec \
   --dangerously-bypass-approvals-and-sandbox \
@@ -287,7 +288,7 @@ def run_codex_for_item(
     task_logs_dir.mkdir(parents=True, exist_ok=True)
 
     (task_work_dir / "solution.py").write_text(item.before, encoding="utf-8")
-    (task_work_dir / "prompt.md").write_text(build_codex_instruction(item), encoding="utf-8")
+    codex_instruction = build_codex_instruction(item)
 
     container_name = f"canitedit-parity-{item.safe_name[:48]}-{uuid.uuid4().hex[:8]}"
     command = [
@@ -307,6 +308,8 @@ def run_codex_for_item(
         "bash",
         "-lc",
         codex_shell_script(args),
+        "canitedit-codex",
+        codex_instruction,
     ]
 
     started = time.time()


### PR DESCRIPTION
## Summary
- add/maintain the Harbor parity Codex runner for CanItEdit while preserving the official prompt and evaluator
- include metadata needed to collect and evaluate Codex completions for the Harbor adapter parity comparison
- clarify parity metadata after the completed 3-run comparison

## Validation
- Branch was used for the completed Harbor/official parity collection reported in the Harbor adapter PR
- No additional code changes were made in this submit step beyond the existing pushed branch commit
